### PR TITLE
Add bargains in form table

### DIFF
--- a/bargains_in_form.py
+++ b/bargains_in_form.py
@@ -1,0 +1,25 @@
+import aiohttp
+from prettytable import PrettyTable
+from fpl import FPL
+
+
+async def bargains_in_form():
+    async with aiohttp.ClientSession() as session:
+        fpl = FPL(session)
+        players = await fpl.get_players()
+
+    top_performers = sorted(players, key=lambda x: x.form, reverse=True)
+
+    player_table = PrettyTable()
+    player_table.field_names = ["Player", "£", "Form"]
+    player_table.align["Player"] = "l"
+
+    for player in top_performers[:100]:
+        if player.now_cost < 60 and float(player.form) > 4.5:
+            # Filter out goalkeepers
+            if player.element_type != 1:
+                player_table.add_row(
+                    [player.web_name, f"£{player.now_cost / 10}", player.form]
+                )
+
+    print(player_table)

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ from fpl import FPL
 
 from goal_contributions import goals_contribution_leaders
 from most_transferred import most_transferred_players
+from bargains_in_form import bargains_in_form
 
 
 async def back_to_menu():
@@ -18,14 +19,20 @@ async def main():
             "What would you like to see?"
             "\n1 - Goal Contribution Leaders"
             "\n2 - Most Transferred Players (this GW)"
+            "\n3 - Bargains in Form"
             "\n"
         )
     )
 
     if menu_selection == 1:
+        # Players with the most goals and assists combined
         await goals_contribution_leaders()
     elif menu_selection == 2:
+        # Most transferred players this GW
         await most_transferred_players()
+    elif menu_selection == 3:
+        # Players in the top 100 in form and under £6.0m (excl GKs)
+        await bargains_in_form()
 
 
 asyncio.run(main())


### PR DESCRIPTION
**_What?_** 
Players in the top 100 of form for the current game week (excluding goalkeepers) that are on the cheaper end of player costs

**_How?_**

- Fetch all players, sorting by form in descending order
- Filter out any player that costs more than £6.0m (now_cost > 60) and has a form less than 4.5
- Filter out all goalkeepers